### PR TITLE
Record: fix for ffmpeg deadlock

### DIFF
--- a/Beheaded/__init__.py
+++ b/Beheaded/__init__.py
@@ -121,7 +121,8 @@ class Record(object):
     def stop(self):
         if self.codec in ["libvpx"]:    # To prevent cutting the recording too soon
             time.sleep(3)
-        self.recorder.send_signal(signal.SIGINT)
+        self.recorder.terminate()
+        (stdout, stderr) = self.recorder.communicate(None)
         returncode = self.recorder.wait()
         if self.terminate_x:
             self.xvfb.stop()


### PR DESCRIPTION
The Record subprocess running ffmpeg sometimes hangs, probably because of output being generated but not consumed (see also deadlock warning on https://docs.python.org/2/library/subprocess.html)

Using the configuration mentioned below, long-running nosetests (10+ minutes) using Beheaded in setup / teardown sometimes did not finish (even when ffmpeg was done writing the recording to disk), while shorter nosetests worked just fine.

Debian 7.6
Linux kernel 3.2 and 3.16
Python 2.7.8
ffmpeg / libav version 0.8.16-6:0.8.16-1
Beheaded, nosetest and selenium installed using pip install
