### PR TITLE
Move -g options after -i options

### DIFF
--- a/Beheaded/__init__.py
+++ b/Beheaded/__init__.py
@@ -131,7 +131,7 @@ class Record(object):
         self.stop()
 
     def _start_ffmpeg(self, xvfb):
-        cmd = "ffmpeg -y -r %d -g 600 -s %dx%d -f x11grab -i :%d -vcodec %s %s" % (
+        cmd = "ffmpeg -y -r %d -s %dx%d -f x11grab -i :%d -g 600 -vcodec %s %s" % (
             self.framerate,
             xvfb.width,
             xvfb.height,


### PR DESCRIPTION
Same issue seen in https://github.com/leonid-shevtsov/headless/issues/52
Solution is to move -g options after the -i options in the command.

Otherwise when using, for example, display :101 I get:

`Codec AVOption g (set the group of picture (GOP) size) specified for input file #0 (:101) is not a decoding option.`
